### PR TITLE
페이지 연결: link to maker-detail

### DIFF
--- a/src/components/Common/CardFindMaker.tsx
+++ b/src/components/Common/CardFindMaker.tsx
@@ -75,9 +75,10 @@ const CardFindMaker = ({
               alt="maker 이미지"
               width={parseInt(computedPhotoSize)}
               height={parseInt(computedPhotoSize)}
-              className="border-2 border-color-blue-400 rounded-full"
+              className="border-2 border-color-blue-400 rounded-full mobile-tablet:hidden"
               
             />
+            <Image src={default_img} alt="파일이미지" width={46} height={46} className="border-2 border-color-blue-400 rounded-full pc:hidden" />
           </div>
           <div className="flex flex-col w-full py-1">
             <div className="w-full flex justify-between ">
@@ -94,6 +95,7 @@ const CardFindMaker = ({
                   alt="별이미지"
                   width={parseInt(computedStarSize)}
                   height={parseInt(computedStarSize)}
+                  className="mobile-tablet:hidden"
                 />
                 <Image src={star} alt="별이미지" width={20} height={20} className="pc:hidden" />
                 <p className=" text-color-black-300">5.0</p>

--- a/src/components/Common/Label.tsx
+++ b/src/components/Common/Label.tsx
@@ -65,6 +65,8 @@ const Label = ({ labelType = 'SHOPPING', labelSize, customLabelContainerClass, c
   
     default:
       labelText = '지정 라벨 없음';
+      containerClass = 'bg-color-gray-100';
+      textClass = 'hidden';
       break;
   }
 

--- a/src/pages/finding-maker.tsx
+++ b/src/pages/finding-maker.tsx
@@ -15,6 +15,15 @@ export default function FindingMaker() {
 
   return (
    <>
+   <style>
+    {`
+      @media (min-width: 1024px) and (max-width: 1800px) {
+        .main-container {
+          padding: 0 72px;
+        }
+      }
+    `}
+   </style>
       <div className="mx-auto overflow-hidden mobile:mx-auto mobile:w-[327px] tablet:mx-auto tablet:w-[600px]">
         <p className="text-2xl py-8 semibold mobile-tablet:hidden pc:block">Maker 찾기</p>
       </div> 

--- a/src/pages/finding-maker.tsx
+++ b/src/pages/finding-maker.tsx
@@ -3,6 +3,7 @@ import DreamerFilter from '../components/Common/DreamerFilter';
 import DropdownSort from "@/components/Common/DropdownSort";
 import CardFindMaker from "@/components/Common/CardFindMaker";
 import SearchBar from "@/components/Common/SearchBar";
+import Link from 'next/link';
 
 export default function FindingMaker() {
   const [searchValue, setSearchValue] = useState('');
@@ -78,14 +79,18 @@ export default function FindingMaker() {
           </div>
           
           <div className="w-full flex flex-col gap-4">
-            <CardFindMaker
-              firstLabelType="SHOPPING"
-              secondLabelType="REQUEST"
-            />
-            <CardFindMaker
-              firstLabelType="SHOPPING"
-              secondLabelType="REQUEST"
-            />
+            <Link href="/maker-detail">
+              <CardFindMaker
+                firstLabelType="SHOPPING"
+                secondLabelType="REQUEST"
+              />
+            </Link>
+            <Link href="/maker-detail">
+              <CardFindMaker
+                firstLabelType="SHOPPING"
+                secondLabelType="REQUEST"
+              />
+            </Link>
           </div>
           
           <div className="flex min-h-[200px] items-center justify-center">

--- a/src/pages/finding-maker.tsx
+++ b/src/pages/finding-maker.tsx
@@ -14,7 +14,7 @@ export default function FindingMaker() {
   };
 
   return (
-   <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12">
+   <>
       <div className="mx-auto overflow-hidden mobile:mx-auto mobile:w-[327px] tablet:mx-auto tablet:w-[600px]">
         <p className="text-2xl py-8 semibold mobile-tablet:hidden pc:block">Maker 찾기</p>
       </div> 
@@ -50,6 +50,7 @@ export default function FindingMaker() {
                 />
                 <CardFindMaker 
                   firstLabelType="SHOPPING"
+                  secondLabelType="REQUEST"
                   labelSize="sm"
                   cardSize="sm"
                 />
@@ -103,6 +104,6 @@ export default function FindingMaker() {
           </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## 작업한 이슈 번호

- close #{번호}

## 작업 사항 설명

내용

## 작업 사항

1. 페이지 연결
finding-maker 페이지 에서 

<img width="533" alt="image" src="https://github.com/user-attachments/assets/f7302f61-2f22-420a-9030-d88350c75116" />

누르면 maker-detail 페이지로 이동합니다. 


2.  테블릿 아하에서 별이 두개로 보이던 미디어쿼리 수정 , 이미지 크기 미디어 쿼리


3. Media query for pedding  
-> 테블릿과 pc 중강지점에서 
<img width="539" alt="image" src="https://github.com/user-attachments/assets/ee838d6b-3564-4309-a9b7-68e5fe0ff708" />

이러한 문제가 있었는데, 

<img width="710" alt="image" src="https://github.com/user-attachments/assets/76184fd4-a7e1-4c0e-be4a-a78c8fd4bfa0" />


이렇게 수정함으로 해결하였습니다. 


https://github.com/user-attachments/assets/fd01cf8d-0d10-4817-8246-6c512cc6f1ee



## 기타

- 어프로브 주시면 머지하겠습니다. 
