### PR TITLE
Feat/#86 리뷰작성페이지 nav 및 일부 UI수정

### DIFF
--- a/src/components/Common/CompleteTrip.tsx
+++ b/src/components/Common/CompleteTrip.tsx
@@ -1,0 +1,12 @@
+export default function CompleteTrip() {
+  return (
+    <div>
+      <div className="mb-12 w-64">
+        <p className="semibold mobile-tablet:medium text-2lg">여행을 완료하시겠습니까?</p>
+      </div>
+      <button className="semibold px-21 w-full rounded-xl bg-blue-500 py-3 text-lg text-white">
+        여행 완료 확정
+      </button>
+    </div>
+  );
+}

--- a/src/components/Common/ReviewForm.tsx
+++ b/src/components/Common/ReviewForm.tsx
@@ -1,0 +1,71 @@
+import Image from "next/image";
+import img_avatar1 from "@public/assets/img_avatar1.svg";
+import { useState } from "react";
+import StarRating from "../Receive/StarRating";
+
+export default function ReviewForm() {
+  const [rating, setRating] = useState<number>(0); // 별점을 상태로 관리
+  const [review, setReview] = useState<string>("");
+
+  const handleRatingChange = (newRating: number) => {
+    setRating(newRating);
+  };
+
+  const handleReviewChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setReview(event.target.value);
+  };
+
+  const isButtonDisabled = review.length < 10 || rating === 0;
+
+  return (
+    <div>
+      <div className="mb-4">
+        <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
+          <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
+            <Image
+              src={img_avatar1}
+              alt="프로필사진"
+              width={80}
+              height={80}
+              className="rounded-full border-2 border-color-blue-400"
+            />
+          </div>
+          <div className="flex w-full">
+            <div className="w-full flex-col items-center justify-between text-xs text-color-black-500">
+              <p className="semibold text-xl mobile-tablet:text-lg">김코드 Maker</p>
+              <div className="flex items-center gap-4 mobile-tablet:gap-1">
+                <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                  <p>여행일</p>
+                  <p className="text-color-gray-400">2024.07.01(월)</p>
+                </div>
+                <p className="text-color-line-200">ㅣ</p>
+                <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                  <p>플랜가</p>
+                  <p className="text-color-gray-400">210,000원</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p className="mb-2 font-medium">평점을 선택해주세요</p>
+        <StarRating initialRating={rating} onRatingChange={handleRatingChange} />
+      </div>
+      <div className="mb-4">
+        <label className="mb-2 block font-medium">상세 후기를 작성해주세요</label>
+        <textarea
+          className="w-full rounded-md border p-2 focus:ring-2 focus:ring-blue-400"
+          placeholder="최소 10자 이상 입력해주세요"
+          rows={4}
+          value={review}
+          onChange={handleReviewChange}
+        ></textarea>
+      </div>
+      <button
+        className={`w-full rounded-xl py-2 text-white ${isButtonDisabled ? "bg-gray-300" : "bg-blue-500"}`}
+        disabled={isButtonDisabled}
+      >
+        리뷰 등록
+      </button>
+    </div>
+  );
+}

--- a/src/components/MyPlans/Cards/PlanCard.tsx
+++ b/src/components/MyPlans/Cards/PlanCard.tsx
@@ -39,7 +39,7 @@ export default function PlanCard({ planData, planId }: PlanCardProps) {
   const selectedPlan = sortedPlans.find((plan) => plan.id === planId);
 
   return (
-    <div className="my-[46px] flex flex-col gap-y-[32px] mobile:gap-y-4 mobile-tablet:my-8">
+    <div className="flex flex-col gap-y-[32px] mobile:gap-y-4 mobile-tablet:my-8">
       <div className="w-fill border-color semibol flex flex-col gap-y-1 rounded-2xl border-[1px] bg-color-background-200 px-10 py-8 text-xl mobile:px-[16px] mobile:py-[16px] mobile-tablet:text-md">
         <div className="flex">
           <label className="w-[150px] text-color-gray-300" htmlFor="requestDate">

--- a/src/components/MyPlans/Cards/RequestCard.tsx
+++ b/src/components/MyPlans/Cards/RequestCard.tsx
@@ -1,29 +1,17 @@
 import Image from "next/image";
-import iconBox from "@public/assets/icon_boximg.png";
-import iconDocument from "@public/assets/icon_document.png";
+import Label from "@/components/Common/Label";
 import icon_like_red from "@public/assets/icon_like_red.png";
 import img_avatar1 from "@public/assets/img_avatar1.svg";
 import icon_active_star from "@public/assets/icon_active_star.svg";
+import link from "@public/assets/icon_link.svg";
 import Link from "next/link";
 
 export default function RequestCard() {
   return (
-    <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 mobile-tablet:px-3 mobile-tablet:py-4">
+    <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 shadow mobile-tablet:px-3 mobile-tablet:py-4">
       <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
-        <div className="flex items-center gap-[4px] rounded-[4px] bg-color-blue-100 p-[4px]">
-          <Image src={iconBox} alt="box" width={24} height={24} className="h-[20px] w-[20px]" />
-          <p className="semibold text-2lg text-color-blue-300 mobile:text-sm">소형 이사</p>
-        </div>
-        <div className="flex items-center gap-[4px] rounded-[4px] bg-color-red-100 p-[4px]">
-          <Image
-            src={iconDocument}
-            alt="document"
-            width={24}
-            height={24}
-            className="h-[20px] w-[20px]"
-          />
-          <p className="semibold text-2lg text-color-red-200 mobile:text-sm">지정 견적 요청</p>
-        </div>
+        <Label labelType="RELAXATION" customLabelContainerClass="rounded-lg" />
+        <Label labelType="REQUEST" customLabelContainerClass="rounded-lg" />
       </div>
       <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
         <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
@@ -50,8 +38,15 @@ export default function RequestCard() {
               </div>
               <p className="text-color-line-200">ㅣ</p>
               <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
-                <p className="text-color-gray-400">경력</p>
-                <p>7년</p>
+                <Link
+                  href="https://www.instagram.com/codeit_kr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex"
+                >
+                  <Image src={link} alt="링크이미지" width={30} height={30} />
+                  <p className="text-color-gray-400">SNS</p>
+                </Link>
               </div>
               <p className="text-color-line-200">ㅣ</p>
               <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
@@ -101,11 +96,9 @@ export default function RequestCard() {
         <button className="semibold w-full text-nowrap rounded-lg bg-color-blue-300 px-[32.5px] py-4 text-xl text-gray-50 mobile:text-md tablet:text-lg mobile-tablet:px-[16px] mobile-tablet:py-[11px]">
           플랜 확정하기
         </button>
-        <Link href={`/mytrip-manage/requestdetail-dreamer/`}>
-          <button className="semibold w-full text-nowrap rounded-lg border-[1px] border-solid border-color-blue-300 px-[32.5px] py-4 text-xl text-color-blue-300 mobile:text-md tablet:text-lg mobile-tablet:px-[16px] mobile-tablet:py-[11px]">
-            상세보기
-          </button>
-        </Link>
+        <button className="semibold w-full text-nowrap rounded-lg border-[1px] border-solid border-color-blue-300 px-[32.5px] py-4 text-xl text-color-blue-300 mobile:text-md tablet:text-lg mobile-tablet:px-[16px] mobile-tablet:py-[11px]">
+          <Link href={`/mytrip-manage/requestdetail-dreamer/`}>상세보기</Link>
+        </button>
       </div>
     </div>
   );

--- a/src/components/MyPlans/Cards/ReuquestCardCompleted.tsx
+++ b/src/components/MyPlans/Cards/ReuquestCardCompleted.tsx
@@ -10,8 +10,8 @@ export default function RequestCardCompleted() {
   return (
     <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 shadow mobile-tablet:px-3 mobile-tablet:py-4">
       <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
-        <Label labelType="RELAXATION" />
-        <Label labelType="REQUEST" />
+        <Label labelType="RELAXATION" customLabelContainerClass="rounded-lg" />
+        <Label labelType="REQUEST" customLabelContainerClass="rounded-lg" />
       </div>
       <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
         <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">

--- a/src/components/MyPlans/Cards/ReuquestCardCompleted.tsx
+++ b/src/components/MyPlans/Cards/ReuquestCardCompleted.tsx
@@ -1,28 +1,17 @@
 import Image from "next/image";
-import iconBox from "@public/assets/icon_boximg.png";
-import iconDocument from "@public/assets/icon_document.png";
+import Label from "@/components/Common/Label";
 import icon_like_red from "@public/assets/icon_like_red.png";
 import img_avatar1 from "@public/assets/img_avatar1.svg";
 import icon_active_star from "@public/assets/icon_active_star.svg";
+import link from "@public/assets/icon_link.svg";
+import Link from "next/link";
 
 export default function RequestCardCompleted() {
   return (
     <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 shadow mobile-tablet:px-3 mobile-tablet:py-4">
       <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
-        <div className="flex items-center gap-[4px] rounded-[4px] bg-color-blue-100 p-[4px]">
-          <Image src={iconBox} alt="box" width={24} height={24} className="h-[20px] w-[20px]" />
-          <p className="semibold text-2lg text-color-blue-300 mobile:text-sm">소형 이사</p>
-        </div>
-        <div className="flex items-center gap-[4px] rounded-[4px] bg-color-red-100 p-[4px]">
-          <Image
-            src={iconDocument}
-            alt="document"
-            width={24}
-            height={24}
-            className="h-[20px] w-[20px]"
-          />
-          <p className="semibold text-2lg text-color-red-200 mobile:text-sm">지정 견적 요청</p>
-        </div>
+        <Label labelType="RELAXATION" />
+        <Label labelType="REQUEST" />
       </div>
       <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
         <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
@@ -49,8 +38,15 @@ export default function RequestCardCompleted() {
               </div>
               <p className="text-color-line-200">ㅣ</p>
               <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
-                <p className="text-color-gray-400">경력</p>
-                <p>7년</p>
+                <Link
+                  href="https://www.instagram.com/codeit_kr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex"
+                >
+                  <Image src={link} alt="링크이미지" width={30} height={30} />
+                  <p className="text-color-gray-400">SNS</p>
+                </Link>
               </div>
               <p className="text-color-line-200">ㅣ</p>
               <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">

--- a/src/components/MyPlans/MyPlanDetail.tsx
+++ b/src/components/MyPlans/MyPlanDetail.tsx
@@ -117,7 +117,12 @@ export default function MyPlanDetail() {
     <>
       <MyPlanNav />
       <Layout bodyClass="bg-gray">
-        <PlanCard planData={planDataForCard} planId={selectedPlan.id} />
+        <div className="my-10 flex-col">
+          <div className="my-10 rounded-2xl border-gray-300 bg-color-gray-50 p-5 shadow">
+            <div className="semibold mb-3 text-2xl text-color-black-500">{selectedPlan.name}</div>
+            <PlanCard planData={planDataForCard} planId={selectedPlan.id} />
+          </div>
+        </div>
         <RequestCardList />
       </Layout>
     </>

--- a/src/components/MyPlans/MyPlanDetailCompleted.tsx
+++ b/src/components/MyPlans/MyPlanDetailCompleted.tsx
@@ -119,7 +119,10 @@ export default function MyPlanDetailCompleted() {
       <Layout bodyClass="bg-gray">
         <div className="my-16 rounded-2xl bg-color-gray-50 p-10">
           <p className="semibold text-2xl">플랜 정보</p>
-          <PlanCard planData={planDataForCard} planId={selectedPlan.id} />
+          <div className="my-10 rounded-2xl border-gray-300 p-5 shadow">
+            <div className="semibold mb-3 text-2xl text-color-black-500">{selectedPlan.name}</div>
+            <PlanCard planData={planDataForCard} planId={selectedPlan.id} />
+          </div>
           <div className="flex-col">
             <p className="semibold mb-10 text-2xl">견적 정보</p>
             <RequestCardListCompleted />

--- a/src/components/MyPlans/RequestCardList.tsx
+++ b/src/components/MyPlans/RequestCardList.tsx
@@ -3,7 +3,7 @@ import RequestCard from "./Cards/RequestCard";
 export default function RequestCardList() {
   return (
     <>
-      <div className="pc:grid pc:grid-cols-2 mobile-tablet:flex mobile-tablet:flex-col gap-4 justify-center items-center">
+      <div className="items-center justify-center gap-4 pc:grid pc:grid-cols-2 mobile-tablet:flex mobile-tablet:flex-col">
         <RequestCard />
         <RequestCard />
         <RequestCard />

--- a/src/components/MyReviews/Cards/ReviewCard.tsx
+++ b/src/components/MyReviews/Cards/ReviewCard.tsx
@@ -1,0 +1,60 @@
+import Image from "next/image";
+import img_avatar1 from "@public/assets/img_avatar1.svg";
+import Label from "@/components/Common/Label";
+import StarRating from "@/components/Receive/StarRating";
+
+export default function ReviewCard() {
+  return (
+    <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 mobile-tablet:px-3 mobile-tablet:py-4">
+      <div className="flex justify-between">
+        <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
+          <Label labelType="SHOPPING" customLabelContainerClass="rounded-lg" />
+        </div>
+        <p className="regular text-2lg text-color-gray-300 mobile-tablet:hidden">
+          작성일 2024.07.02
+        </p>
+      </div>
+      <div className="border-color bg-body.bg-gray mobile-tablet:px-[10px]mobile-tablet:border-color my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:rounded-none mobile-tablet:border-b-[1px] mobile-tablet:px-[10px]">
+        <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
+          <Image
+            src={img_avatar1}
+            alt="프로필사진"
+            width={80}
+            height={80}
+            className="rounded-full border-2 border-color-blue-400"
+          />
+        </div>
+        <div className="flex w-full">
+          <div className="w-full flex-col items-center justify-between gap-2 text-xs text-color-black-500">
+            <p className="semibold text-xl mobile-tablet:text-lg">김코드 Maker</p>
+            <div className="flex items-center gap-4 mobile-tablet:gap-1">
+              <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                <p>여행일</p>
+                <p className="text-color-gray-400">2024.07.01(월)</p>
+              </div>
+              <p className="text-color-line-200">ㅣ</p>
+              <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                <p>플랜가</p>
+                <p className="text-color-gray-400">210,000원</p>
+              </div>
+            </div>
+            <div className="mobile-tablet:hidden">
+              <StarRating type={true} initialRating={5} readonly={true} />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <p className="regular p-2 text-xl text-color-gray-500 mobile-tablet:text-md">
+          처음 플랜 받아봤는데, 엄청 친절하시고 꼼꼼하세요! 귀찮게 이것저것 물어봤는데 잘
+          알려주셨습니다. 국내 여행은 믿고 맡기세요!
+        </p>
+      </div>
+      <div>
+        <p className="regular text-right text-md text-color-gray-300 pc:hidden">
+          작성일 2024.07.02
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MyReviews/Cards/TripCard.tsx
+++ b/src/components/MyReviews/Cards/TripCard.tsx
@@ -1,0 +1,86 @@
+import Image from "next/image";
+import img_avatar1 from "@public/assets/img_avatar1.svg";
+import Label from "@/components/Common/Label";
+import ReceiveModalLayout from "@/components/Receive/ReceiveModalLayout";
+import ReviewForm from "@/components/Common/ReviewForm";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import CompleteTrip from "@/components/Common/CompleteTrip";
+
+export default function TripCard() {
+  const router = useRouter();
+  const [isReviewModalOpen, setIsReviewModalOpen] = useState<boolean>(false);
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState<boolean>(false);
+
+  const isCompletedTrip = router.asPath.includes("completed-trip");
+  const isReviewableTrip = router.asPath.includes("reviewable-trip");
+
+  const openReviewModal = () => setIsReviewModalOpen(true);
+  const closeReviewModal = () => setIsReviewModalOpen(false);
+
+  const openCompleteModal = () => setIsCompleteModalOpen(true);
+  const closeCompleteModal = () => setIsCompleteModalOpen(false);
+
+  return (
+    <div className="mb-[32px] flex flex-col rounded-2xl bg-color-gray-50 px-6 py-7 mobile-tablet:px-3 mobile-tablet:py-4">
+      <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
+        <Label labelType="SHOPPING" customLabelContainerClass="rounded-lg" />
+      </div>
+      <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
+        <div className="flex h-20 w-20 flex-shrink-0 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
+          <Image
+            src={img_avatar1}
+            alt="프로필사진"
+            width={80}
+            height={80}
+            className="rounded-full border-2 border-color-blue-400"
+          />
+        </div>
+        <div className="flex w-full">
+          <div className="w-full flex-col items-center justify-between text-xs text-color-black-500">
+            <p className="semibold text-xl mobile-tablet:text-lg">김코드 Maker</p>
+            <div className="flex items-center gap-2 mobile-tablet:gap-1">
+              <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                <p>여행일</p>
+                <p className="text-color-gray-400">2024.07.01(월)</p>
+              </div>
+              <p className="text-color-line-200">ㅣ</p>
+              <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
+                <p>플랜가</p>
+                <p className="text-color-gray-400">210,000원</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-between gap-[11px] mobile:flex-col">
+        {isCompletedTrip && (
+          <button
+            className="semibold w-full text-nowrap rounded-lg bg-color-blue-300 px-[32.5px] py-4 text-xl text-gray-50 mobile:text-md tablet:text-lg mobile-tablet:px-[16px] mobile-tablet:py-[11px]"
+            onClick={openCompleteModal}
+          >
+            여행 완료하기
+          </button>
+        )}
+        {isReviewableTrip && (
+          <button
+            className="semibold w-full text-nowrap rounded-lg bg-color-blue-300 px-[32.5px] py-4 text-xl text-gray-50 mobile:text-md tablet:text-lg mobile-tablet:px-[16px] mobile-tablet:py-[11px]"
+            onClick={openReviewModal}
+          >
+            리뷰 작성하기
+          </button>
+        )}
+      </div>
+      {isCompleteModalOpen && (
+        <ReceiveModalLayout label="여행 완료" closeModal={closeCompleteModal}>
+          <CompleteTrip />
+        </ReceiveModalLayout>
+      )}
+      {isReviewModalOpen && (
+        <ReceiveModalLayout label="리뷰 작성" closeModal={closeReviewModal}>
+          <ReviewForm />
+        </ReceiveModalLayout>
+      )}
+    </div>
+  );
+}

--- a/src/components/MyReviews/MyCompletedTripList.tsx
+++ b/src/components/MyReviews/MyCompletedTripList.tsx
@@ -1,0 +1,16 @@
+import TripCard from "./Cards/TripCard";
+
+export default function MyCompletedTripList() {
+  return (
+    <>
+      <div className="items-center justify-center gap-4 pc:grid pc:grid-cols-2 mobile-tablet:flex mobile-tablet:flex-col">
+        <TripCard />
+        <TripCard />
+        <TripCard />
+        <TripCard />
+        <TripCard />
+        <TripCard />
+      </div>
+    </>
+  );
+}

--- a/src/components/MyReviews/MyReviewList.tsx
+++ b/src/components/MyReviews/MyReviewList.tsx
@@ -1,0 +1,16 @@
+import ReviewCard from "./Cards/ReviewCard";
+
+export default function MyReviewList() {
+  return (
+    <>
+      <div className="items-center justify-center gap-4 pc:grid pc:grid-cols-2 mobile-tablet:flex mobile-tablet:flex-col">
+        <ReviewCard />
+        <ReviewCard />
+        <ReviewCard />
+        <ReviewCard />
+        <ReviewCard />
+        <ReviewCard />
+      </div>
+    </>
+  );
+}

--- a/src/components/MyReviews/MyReviewNav.tsx
+++ b/src/components/MyReviews/MyReviewNav.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export default function MyReviewNav() {
+  const router = useRouter();
+  const activeTab = router.pathname.split("/").pop();
+
+  return (
+    <div className="relative left-1/2 w-screen -translate-x-1/2 bg-color-background-100 px-[260px] mobile:px-0 tablet:px-[72px]">
+      <div className="max-w-screen-xl semibold mx-auto flex gap-[32px] px-[16px] text-xl text-color-gray-400 mobile-tablet:gap-[24px] mobile-tablet:text-md">
+        <Link href="/myreview-manage/completed-trip">
+          <button
+            className={`py-[16px] ${
+              activeTab === "completed-trip"
+                ? "border-b-2 border-color-black-500 text-color-black-500"
+                : ""
+            }`}
+          >
+            <p className="text-nowrap">완료 가능한 여행</p>
+          </button>
+        </Link>
+        <Link href="/myreview-manage/reviewable-trip">
+          <button
+            className={`py-[16px] ${
+              activeTab === "reviewable-trip" ? "border-b-2 border-black text-color-black-500" : ""
+            }`}
+          >
+            <p className="text-nowrap">작성 가능한 리뷰</p>
+          </button>
+        </Link>
+        <Link href="/myreview-manage/reviewed-trip">
+          <button
+            className={`py-[16px] ${
+              activeTab === "reviewed-trip" ? "border-b-2 border-black text-color-black-500" : ""
+            }`}
+          >
+            <p className="text-nowrap">내가 작성한 리뷰</p>
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Receive/ReceiveModalLayout.tsx
+++ b/src/components/Receive/ReceiveModalLayout.tsx
@@ -16,9 +16,9 @@ export default function ReceiveModalLayout({ label, children, closeModal }: Moda
   }, []);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center mobile:items-end overflow-y-scroll pt-[100px] mobile-tablet::pt-0 ">
-      <div className="bg-white rounded-2xl  px-[24px] py-[32px]  mobile:rounded-b-none mobile:pb-[32px]">
-        <div className="flex text-2xl font-bold justify-between items-center mb-10 tablet:text-2lg tablet:mb-[24px] mobile:mb-[24px] ">
+    <div className="mobile-tablet::pt-0 fixed inset-0 flex items-center justify-center overflow-y-scroll bg-black bg-opacity-50 pt-[100px] mobile:items-end">
+      <div className="rounded-2xl bg-white px-[24px] py-[32px] mobile:rounded-b-none mobile:pb-[32px]">
+        <div className="mb-10 flex items-center justify-between text-2xl font-bold mobile:mb-[24px] tablet:mb-[24px] tablet:text-2lg">
           {label}
           <Image
             src={closeIcon}
@@ -26,7 +26,7 @@ export default function ReceiveModalLayout({ label, children, closeModal }: Moda
             width={36}
             height={36}
             onClick={closeModal}
-            className="cursor-pointer tablet:w-[24px] tablet:h-[24px] "
+            className="cursor-pointer tablet:h-[24px] tablet:w-[24px]"
           />
         </div>
         {children}

--- a/src/components/Receive/StarRating.tsx
+++ b/src/components/Receive/StarRating.tsx
@@ -39,7 +39,7 @@ export default function StarRating({
           onMouseEnter={() => !readonly && setHover(star)}
           onMouseLeave={() => !readonly && setHover(0)}
           disabled={readonly}
-          className={` ${!readonly && "hover:scale-110 transition-transform"}`}
+          className={` ${!readonly && "transition-transform hover:scale-110"}`}
         >
           {type ? (
             <Image

--- a/src/features/DetailMaker.tsx
+++ b/src/features/DetailMaker.tsx
@@ -2,6 +2,7 @@
 
 interface KakaoSDK {
   init: (key: string) => void;
+  isInitialized: () => boolean;
   Share: {
     sendScrap: (options: { requestUrl: string }) => void;
   };
@@ -12,6 +13,7 @@ declare global {
     Kakao: KakaoSDK;
   }
 }
+
 import Image from "next/image";
 import icon_like_red from "@public/assets/icon_like_red.png";
 import icon_like_black from "@public/assets/icon_like_black.svg";
@@ -58,11 +60,12 @@ export default function RequestDetailDreamer() {
     // 여기서 페이지 변경에 따른 데이터 fetch 로직 구현
   };
 
-  /*eslint-disable*/
   useEffect(() => {
     if (typeof window !== "undefined" && window.Kakao) {
       const Kakao = window.Kakao;
-      Kakao.init("0337a68dec8e9d5ebea78113c3b9fc62");
+      if (!Kakao.isInitialized()) {
+        Kakao.init("0337a68dec8e9d5ebea78113c3b9fc62");
+      }
     }
   }, []);
   //init괄호 안에는 카카오디벨로퍼스에서 받은 javascript키 입력

--- a/src/pages/myreview-manage/completed-trip/index.tsx
+++ b/src/pages/myreview-manage/completed-trip/index.tsx
@@ -1,0 +1,32 @@
+import Layout from "@/components/Common/Layout";
+import Pagination from "@/components/Common/Pagination";
+import MyCompletedTripList from "@/components/MyReviews/MyCompletedTripList";
+import MyReviewNav from "@/components/MyReviews/MyReviewNav";
+import { useState } from "react";
+
+export default function CompletedTrip() {
+  const [currentPage, setCurrentPage] = useState<number>(1); // 현재 페이지 상태
+  const totalPages = 10; // 총 페이지 수
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    console.log(`Changed to page: ${page}`); // 디버깅용
+  };
+
+  return (
+    <>
+      <MyReviewNav />
+      <Layout bodyClass="bg-gray">
+        <div className="my-10">
+          <MyCompletedTripList />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/myreview-manage/reviewable-trip/index.tsx
+++ b/src/pages/myreview-manage/reviewable-trip/index.tsx
@@ -1,0 +1,32 @@
+import Layout from "@/components/Common/Layout";
+import Pagination from "@/components/Common/Pagination";
+import MyCompletedTripList from "@/components/MyReviews/MyCompletedTripList";
+import MyReviewNav from "@/components/MyReviews/MyReviewNav";
+import { useState } from "react";
+
+export default function ReviewableTrip() {
+  const [currentPage, setCurrentPage] = useState<number>(1); // 현재 페이지 상태
+  const totalPages = 10; // 총 페이지 수
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    console.log(`Changed to page: ${page}`); // 디버깅용
+  };
+
+  return (
+    <>
+      <MyReviewNav />
+      <Layout bodyClass="bg-gray">
+        <div className="my-10">
+          <MyCompletedTripList />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/myreview-manage/reviewed-trip/index.tsx
+++ b/src/pages/myreview-manage/reviewed-trip/index.tsx
@@ -1,0 +1,32 @@
+import Layout from "@/components/Common/Layout";
+import Pagination from "@/components/Common/Pagination";
+import MyReviewList from "@/components/MyReviews/MyReviewList";
+import MyReviewNav from "@/components/MyReviews/MyReviewNav";
+import { useState } from "react";
+
+export default function CompletedTrip() {
+  const [currentPage, setCurrentPage] = useState<number>(1); // 현재 페이지 상태
+  const totalPages = 10; // 총 페이지 수
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    console.log(`Changed to page: ${page}`); // 디버깅용
+  };
+
+  return (
+    <>
+      <MyReviewNav />
+      <Layout bodyClass="bg-gray">
+        <div className="my-10">
+          <MyReviewList />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </Layout>
+    </>
+  );
+}

--- a/src/pages/mytrip-manage/requestdetail-dreamer/index.tsx
+++ b/src/pages/mytrip-manage/requestdetail-dreamer/index.tsx
@@ -3,6 +3,7 @@
 
 interface KakaoSDK {
   init: (key: string) => void;
+  isInitialized: () => boolean;
   Share: {
     sendScrap: (options: { requestUrl: string }) => void;
   };
@@ -15,8 +16,7 @@ declare global {
 }
 
 import Image from "next/image";
-import iconBox from "@public/assets/icon_boximg.png";
-import iconDocument from "@public/assets/icon_document.png";
+import Label from "@/components/Common/Label";
 import icon_like_red from "@public/assets/icon_like_red.png";
 import icon_like_black from "@public/assets/icon_like_black.svg";
 import img_avatar1 from "@public/assets/img_avatar1.svg";
@@ -24,17 +24,20 @@ import icon_active_star from "@public/assets/icon_active_star.svg";
 import icon_outline from "@public/assets/icon_outline.png";
 import icon_kakao from "@public/assets/icon_kakao.png";
 import icon_facebook from "@public/assets/icon_facebook.png";
+import link from "@public/assets/icon_link.svg";
+import Link from "next/link";
 import PlanCard from "@/components/MyPlans/Cards/PlanCard";
 import { useEffect } from "react";
 import ClipboardCopy from "@/components/Common/ClipboardCopy";
 import { useRouter } from "next/router";
 
 export default function RequestDetailDreamer() {
-  /*eslint-disable*/
   useEffect(() => {
     if (typeof window !== "undefined" && window.Kakao) {
       const Kakao = window.Kakao;
-      Kakao.init("0337a68dec8e9d5ebea78113c3b9fc62");
+      if (!Kakao.isInitialized()) {
+        Kakao.init("0337a68dec8e9d5ebea78113c3b9fc62");
+      }
     }
   }, []);
   //init괄호 안에는 카카오디벨로퍼스에서 받은 javascript키 입력
@@ -140,28 +143,8 @@ export default function RequestDetailDreamer() {
           <div className="flex">
             <div className="flex w-full flex-col rounded-2xl bg-color-gray-50 px-6 py-7 mobile-tablet:px-3 mobile-tablet:py-4">
               <div className="justify-left flex items-center gap-[12px] mobile-tablet:mt-[6px]">
-                <div className="flex items-center gap-[4px] rounded-[4px] bg-color-blue-100 p-[4px]">
-                  <Image
-                    src={iconBox}
-                    alt="box"
-                    width={24}
-                    height={24}
-                    className="h-[20px] w-[20px]"
-                  />
-                  <p className="semibold text-2lg text-color-blue-300 mobile:text-sm">소형 이사</p>
-                </div>
-                <div className="flex items-center gap-[4px] rounded-[4px] bg-color-red-100 p-[4px]">
-                  <Image
-                    src={iconDocument}
-                    alt="document"
-                    width={24}
-                    height={24}
-                    className="h-[20px] w-[20px]"
-                  />
-                  <p className="semibold text-2lg text-color-red-200 mobile:text-sm">
-                    지정 견적 요청
-                  </p>
-                </div>
+                <Label labelType="RELAXATION" customLabelContainerClass="rounded-lg" />
+                <Label labelType="REQUEST" customLabelContainerClass="rounded-lg" />
               </div>
               <div className="border-color bg-body.bg-gray my-6 flex gap-6 rounded-md border-[1px] px-[18px] py-4 mobile-tablet:my-[14px] mobile-tablet:gap-3 mobile-tablet:px-[10px]">
                 <div className="flex h-20 w-20 items-center mobile-tablet:h-[46px] mobile-tablet:w-[46px]">
@@ -188,8 +171,15 @@ export default function RequestDetailDreamer() {
                       </div>
                       <p className="mx-4 text-color-line-200 mobile-tablet:mx-1">ㅣ</p>
                       <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
-                        <p className="text-color-gray-400">경력</p>
-                        <p>7년</p>
+                        <Link
+                          href="https://www.instagram.com/codeit_kr/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex"
+                        >
+                          <Image src={link} alt="링크이미지" width={30} height={30} />
+                          <p className="text-color-gray-400">SNS</p>
+                        </Link>
                       </div>
                       <p className="mx-4 text-color-line-200 mobile-tablet:mx-1">ㅣ</p>
                       <div className="medium flex flex-shrink-0 gap-[6px] text-lg mobile-tablet:gap-[5px] mobile-tablet:text-sm">
@@ -239,7 +229,7 @@ export default function RequestDetailDreamer() {
           </div>
           <hr className="border-Line-100 my-6 pc:hidden" />
           <div>
-            <p className="semibold text-2xl text-color-black-400">플랜 정보</p>
+            <p className="semibold mb-8 text-2xl text-color-black-400">플랜 정보</p>
             <PlanCard planData={planDataForCard} planId={selectedPlan.id} />
           </div>
         </div>


### PR DESCRIPTION
## 작업한 이슈 번호

- close #{86}

## 작업 사항 설명

리뷰 관리 페이지 기초 UI 및 카카오 첫 렌더링시 초기화 방지

## 작업 사항

- [x] 리뷰작성 NAV
- [x] 각 페이지 내부 UI
- [x]  리뷰작성 및 여행 확정 모달(ReceiveModalLayout 활용)
- [x] 임시 라벨들 Label컴포넌트로 교체
- [x] 메이커 정보란의 경력 -> SNS로 변경
- [x] PlanCard컴포넌트 기본 my 삭제(제가 알고있는곳은 간격 조절 다 했습니다! 혹시 사용하셨다면 CSS점검 해주세요)

## 기타

- 
