### PR TITLE
Feat/#95 navBar 프로필 이미지 추가

### DIFF
--- a/src/components/Gnb/NavBar.tsx
+++ b/src/components/Gnb/NavBar.tsx
@@ -15,6 +15,17 @@ import userService from "@/services/userService";
 import notificationService, { NotificationProps } from "@/services/notificationService";
 import { useRouter } from "next/router";
 import { useQuery } from "@tanstack/react-query";
+import DEFAULT_1 from "@public/assets/img_avatar1.svg";
+import DEFAULT_2 from "@public/assets/img_avatar2.svg";
+import DEFAULT_3 from "@public/assets/img_avatar3.svg";
+import DEFAULT_4 from "@public/assets/img_avatar4.svg";
+
+const avatarImages = [
+  { key: "DEFAULT_1", src: DEFAULT_1 },
+  { key: "DEFAULT_2", src: DEFAULT_2 },
+  { key: "DEFAULT_3", src: DEFAULT_3 },
+  { key: "DEFAULT_4", src: DEFAULT_4 },
+];
 
 interface LinkItem {
   href: string;
@@ -48,6 +59,7 @@ const NavBar = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [userInfo, setUserInfo] = useState<any>(null);
   const [notifications, setNotifications] = useState<NotificationProps[]>([]);
+  const [userImage, setUserImage] = useState<string>(user_img.src);
 
   const router = useRouter();
 
@@ -133,7 +145,11 @@ const NavBar = () => {
       const fetchUserInfo = async () => {
         try {
           const userData = await userService.getUserInfo();
+          const profileData = await userService.getProfileInfo();
+
           setUserInfo(userData);
+          const avatarImage = avatarImages.find((avatar) => avatar.key === profileData.image);
+          setUserImage(avatarImage ? avatarImage.src : user_img.src);
           setLogin(userData.nickName, userData.role, userData.coconut);
         } catch (error) {
           console.error(error);
@@ -200,7 +216,13 @@ const NavBar = () => {
               className="flex cursor-pointer items-center space-x-2"
               onClick={handleOpenUserMenu}
             >
-              <Image src={user_img} alt="유저이미지" width={36} height={36} />
+              <Image
+                src={userImage}
+                alt="유저이미지"
+                width={36}
+                height={36}
+                className="rounded-full"
+              />
               <span className="medium hidden text-2lg pc:block">
                 {nickName} {role}
               </span>


### PR DESCRIPTION
## 작업한 이슈 번호

- close #95 

## 작업 사항 설명

피드백 받은 수정사항 고치기

## TO-DO

- [x] navBar 프로필 이미지 띄우기

## 기타

- 기본 유저 이미지를 실제 프로필로 매핑했습니다!

![image](https://github.com/user-attachments/assets/36f1c29b-23e5-4ddc-8338-c33fe267f7e9)
