### PR TITLE
[현준배] maker찾기 카드 라벨 및 드롭다운 크기 UI

### DIFF
--- a/public/assets/label_more.svg
+++ b/public/assets/label_more.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="6" cy="12" r="2" fill="#000" />
+  <circle cx="12" cy="12" r="2" fill="#000" />
+  <circle cx="18" cy="12" r="2" fill="#000" />
+</svg>

--- a/src/components/Common/CardFindMaker.tsx
+++ b/src/components/Common/CardFindMaker.tsx
@@ -69,8 +69,7 @@ const CardFindMaker = ({
      ${cardClassName} ${cardSize === 'sm' ? '!w-[327px] !h-[188px] py-4 px-[14px]' : ''} tablet:w-full tablet:h-[188px] mobile:w-full mobile:h-[188px]`}>
       <div className="flex mb-2 gap-4">
         
-      
-      {(serviceTypes || []).map((type, index) => (
+      {(serviceTypes || []).slice(0, cardSize === 'sm' ? 2 : serviceTypes.length).map((type, index) => (
         <Label 
           key={`${type}-${index}`}
           labelType={type}

--- a/src/components/Common/CardFindMaker.tsx
+++ b/src/components/Common/CardFindMaker.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import link from "@public/assets/icon_link.svg";
 import { ServiceType } from "@/services/userService";
 import React, { useState, useEffect, useRef } from 'react';
+import moreIcon from "@public/assets/label_more.svg";
 
 interface CardFindMakerProps {
   
@@ -93,7 +94,7 @@ const CardFindMaker = ({
     >
       <div className="flex mb-2 gap-4">
         
-      {(serviceTypes || []).slice(0, cardWidth < 373 ? 2 : (cardWidth < 840 ? 3 : serviceTypes.length)).map((type, index) => (
+      {(serviceTypes || []).slice(0, cardWidth < 410 ? 2 : (cardWidth< 586 ? 3 : (cardWidth < 716 ? 4 : (cardWidth < 840 ? 5 : serviceTypes.length)))).map((type, index) => (
         <Label 
           key={`${type}-${index}`}
           labelType={type}
@@ -102,6 +103,14 @@ const CardFindMaker = ({
           customLabelTextClass={customLabelTextClass}
         />
       ))}
+      {serviceTypes.length > (cardWidth < 410 ? 2 : (cardWidth < 586 ? 3 : (cardWidth < 716 ? 4 : (cardWidth < 840 ? 5 : serviceTypes.length)))) && (
+        <Image
+          src={moreIcon}
+          alt="더 있음"
+          width={24}
+          height={24}
+        />
+      )}
       </div>
 
       <h2 className={`mb-4 text-2xl semibold text-color-black-300 ${titleSize} ${cardSize === 'sm' ? 'text-md !mb-1' : ''} mobile-tablet:text-sm`}>

--- a/src/components/Common/CardFindMaker.tsx
+++ b/src/components/Common/CardFindMaker.tsx
@@ -7,6 +7,8 @@ import avatarImages from "@/utils/formatImage";
 import Link from "next/link";
 import link from "@public/assets/icon_link.svg";
 import { ServiceType } from "@/services/userService";
+import React, { useState, useEffect, useRef } from 'react';
+
 interface CardFindMakerProps {
   
   labelSize?: 'sm';
@@ -64,12 +66,34 @@ const CardFindMaker = ({
   const isSmallScreen = typeof window !== 'undefined' && window.innerWidth < 1023; 
   const computedPhotoSize = cardSize === 'sm' || isSmallScreen ? "46" : photoSize;
   const computedStarSize = cardSize === 'sm' || isSmallScreen ? "20" : starSize;
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [cardWidth, setCardWidth] = useState<number>(0);
+
+  useEffect(() => {
+    const updateCardWidth = () => {
+      if (cardRef.current) {
+        setCardWidth(cardRef.current.offsetWidth);
+      }
+    };
+
+    updateCardWidth();
+    window.addEventListener('resize', updateCardWidth);
+
+    return () => {
+      window.removeEventListener('resize', updateCardWidth);
+    };
+  }, []);
+
   return (
-    <div className={`w-full h-[230px] border border-color-line-100 rounded-lg py-5 px-6 shadow-[2px_2px_10px_rgba(220,220,220,0.14),-2px_-2px_10px_rgba(220,220,220,0.14)]
-     ${cardClassName} ${cardSize === 'sm' ? '!w-[327px] !h-[188px] py-4 px-[14px]' : ''} tablet:w-full tablet:h-[188px] mobile:w-full mobile:h-[188px]`}>
+    <div
+      ref={cardRef}
+      className={`w-full h-[230px] border border-color-line-100 rounded-lg py-5 px-6 shadow-[2px_2px_10px_rgba(220,220,220,0.14),-2px_-2px_10px_rgba(220,220,220,0.14)]
+      ${cardClassName} ${cardSize === 'sm' ? '!w-[327px] !h-[188px] py-4 px-[14px]' : ''} tablet:w-full tablet:h-[188px] mobile:w-full mobile:h-[188px] 
+      `}
+    >
       <div className="flex mb-2 gap-4">
         
-      {(serviceTypes || []).slice(0, cardSize === 'sm' ? 2 : serviceTypes.length).map((type, index) => (
+      {(serviceTypes || []).slice(0, cardWidth < 373 ? 2 : (cardWidth < 840 ? 3 : serviceTypes.length)).map((type, index) => (
         <Label 
           key={`${type}-${index}`}
           labelType={type}

--- a/src/components/Common/DropdownSort.tsx
+++ b/src/components/Common/DropdownSort.tsx
@@ -48,7 +48,7 @@ const DropdownSort = ({ onSort }: DropdownSortProps) => {
     <div ref={dropdownRef} className="w-full relative">
       <button
         onClick={toggleDropdown}
-        className="w-[114px] h-[40px] px-[10px] py-2 flex justify-between items-center rounded-[8px] cursor-pointer transition duration-200"
+        className="w-[115px] h-[40px] px-[10px] py-2 flex justify-between items-center rounded-[8px] cursor-pointer transition duration-200"
       >
         <p className="text-color-black-400 text-md semibold mobile-tablet:text-xs">
           {selectedItem || placeholder}

--- a/src/components/Common/DropdownSort.tsx
+++ b/src/components/Common/DropdownSort.tsx
@@ -48,7 +48,7 @@ const DropdownSort = ({ onSort }: DropdownSortProps) => {
     <div ref={dropdownRef} className="w-full relative">
       <button
         onClick={toggleDropdown}
-        className="w-[114px] h-[40px] px-[10px] py-2 flex justify-between items-center rounded-[8px] cursor-pointer transition duration-200 bg-color-gray-50"
+        className="w-[114px] h-[40px] px-[10px] py-2 flex justify-between items-center rounded-[8px] cursor-pointer transition duration-200"
       >
         <p className="text-color-black-400 text-md semibold mobile-tablet:text-xs">
           {selectedItem || placeholder}


### PR DESCRIPTION
## 작업한 이슈 번호

- close #142 

## 작업 사항 설명

<img width="574" alt="image" src="https://github.com/user-attachments/assets/0b509c83-667a-459a-bd97-2a71fb5cbea8" />

1차수정
<img width="801" alt="image" src="https://github.com/user-attachments/assets/1aff4edb-790f-47db-b9da-4fc572a2f941" />

2차 수정 
- [x] more 아이콘 추가

https://github.com/user-attachments/assets/58564b4f-1f1a-43e9-bf3e-bec2d2013790



## 기타

- 화면 사이즈에 따라 바뀌는 것이 아닌 미래성과 유지보수를 고려하여 카드 컴포넌트 사이즈(미디어 쿼리시 실제로 적용되는 크기) 에 따라 반응하고 적용 되도록 하였습니다. 

- 어프로브 주시면 바로 머지하겠습니다. 

